### PR TITLE
add common headers

### DIFF
--- a/src/cpp.rs
+++ b/src/cpp.rs
@@ -7369,16 +7369,50 @@ pub mod root {
                     pub fn pos_2d(arg1: *mut root::app::BattleObjectModuleAccessor) -> u64;
                 }
                 extern "C" {
+                    /// Returns stage X position of the object
+                    ///
+                    /// # Arguments
+                    ///
+                    /// * `module_accessor` - Pointer to BattleObjectModuleAccessor
+                    ///
+                    /// # Example
+                    ///
+                    /// ```
+                    /// // is on right side of the stage
+                    /// if PostureModule::pos_x(module_accessor) > 0 {
+                    ///     // ...
+                    /// }
+                    /// ```
                     #[link_name = "\u{1}_ZN3app8lua_bind25PostureModule__pos_x_implEPNS_26BattleObjectModuleAccessorE"]
-                    pub fn pos_x(arg1: *mut root::app::BattleObjectModuleAccessor) -> f32;
+                    pub fn pos_x(module_accessor: *mut root::app::BattleObjectModuleAccessor) -> f32;
                 }
                 extern "C" {
+                    /// Returns stage Y position of the object
+                    ///
+                    /// # Arguments
+                    ///
+                    /// * `module_accessor` - Pointer to BattleObjectModuleAccessor
+                    ///
+                    /// # Example
+                    ///
+                    /// ```
+                    /// // is above Final Destination stage level
+                    /// if PostureModule::pos_y(module_accessor) > 0 {
+                    ///     // ...
+                    /// }
+                    /// ```
                     #[link_name = "\u{1}_ZN3app8lua_bind25PostureModule__pos_y_implEPNS_26BattleObjectModuleAccessorE"]
-                    pub fn pos_y(arg1: *mut root::app::BattleObjectModuleAccessor) -> f32;
+                    pub fn pos_y(module_accessor: *mut root::app::BattleObjectModuleAccessor) -> f32;
                 }
                 extern "C" {
+                    /// Returns stage Z position of the object
+                    ///
+                    /// # Arguments
+                    ///
+                    /// * `module_accessor` - Pointer to BattleObjectModuleAccessor
+                    ///
                     #[link_name = "\u{1}_ZN3app8lua_bind25PostureModule__pos_z_implEPNS_26BattleObjectModuleAccessorE"]
-                    pub fn pos_z(arg1: *mut root::app::BattleObjectModuleAccessor) -> f32;
+                    pub fn pos_z(module_accessor: *mut root::app::BattleObjectModuleAccessor) -> f32;
                 }
                 extern "C" {
                     #[link_name = "\u{1}_ZN3app8lua_bind27PostureModule__set_pos_implEPNS_26BattleObjectModuleAccessorERKN3phx8Vector3fE"]

--- a/src/cpp.rs
+++ b/src/cpp.rs
@@ -7379,7 +7379,7 @@ pub mod root {
                     ///
                     /// ```
                     /// // is on right side of the stage
-                    /// if PostureModule::pos_x(module_accessor) > 0 {
+                    /// if PostureModule::pos_x(module_accessor) > 0.0 {
                     ///     // ...
                     /// }
                     /// ```
@@ -7397,7 +7397,7 @@ pub mod root {
                     ///
                     /// ```
                     /// // is above Final Destination stage level
-                    /// if PostureModule::pos_y(module_accessor) > 0 {
+                    /// if PostureModule::pos_y(module_accessor) > 0.0 {
                     ///     // ...
                     /// }
                     /// ```
@@ -14898,16 +14898,30 @@ pub mod root {
                     ) -> u64;
                 }
                 extern "C" {
+                    /// Returns current status kind of the object
+                    ///
+                    /// # Arguments
+                    ///
+                    /// * `module_accessor` - Pointer to BattleObjectModuleAccessor
+                    ///
+                    /// # Example
+                    ///
+                    /// ```
+                    /// // fighter is shielding
+                    /// if StatusModule::status_kind(module_accessor) == FIGHTER_STATUS_KIND_GUARD {
+                    ///     StatusModule::change_status_request(module_accessor, *FIGHTER_STATUS_KIND_JUMP_SQUAT, false);
+                    /// }
+                    /// ```
                     #[link_name = "\u{1}_ZN3app8lua_bind30StatusModule__status_kind_implEPNS_26BattleObjectModuleAccessorE"]
                     pub fn status_kind(
-                        arg1: *mut root::app::BattleObjectModuleAccessor,
+                        module_accessor: *mut root::app::BattleObjectModuleAccessor,
                     ) -> i32;
                 }
                 extern "C" {
                     #[link_name = "\u{1}_ZN3app8lua_bind35StatusModule__status_kind_next_implEPNS_26BattleObjectModuleAccessorE"]
                     pub fn status_kind_next(
                         arg1: *mut root::app::BattleObjectModuleAccessor,
-                    ) -> u64;
+                    ) -> i32;
                 }
                 extern "C" {
                     #[link_name = "\u{1}_ZN3app8lua_bind44StatusModule__set_status_kind_interrupt_implEPNS_26BattleObjectModuleAccessorEi"]
@@ -14927,10 +14941,25 @@ pub mod root {
                     pub fn is_changing(arg1: *mut root::app::BattleObjectModuleAccessor) -> bool;
                 }
                 extern "C" {
+                    /// Returns one of the previous status kinds of the object
+                    ///
+                    /// # Arguments
+                    ///
+                    /// * `module_accessor` - Pointer to BattleObjectModuleAccessor
+                    /// * `index` - index of prev status list
+                    ///
+                    /// # Example
+                    ///
+                    /// ```
+                    /// // fighter was shielding for its last status
+                    /// if StatusModule::prev_status_kind(module_accessor, 0) == FIGHTER_STATUS_KIND_GUARD {
+                    ///     StatusModule::change_status_request(module_accessor, *FIGHTER_STATUS_KIND_JUMP_SQUAT, false);
+                    /// }
+                    /// ```
                     #[link_name = "\u{1}_ZN3app8lua_bind35StatusModule__prev_status_kind_implEPNS_26BattleObjectModuleAccessorEj"]
                     pub fn prev_status_kind(
-                        arg1: *mut root::app::BattleObjectModuleAccessor,
-                        arg2: libc::c_uint,
+                        module_accessor: *mut root::app::BattleObjectModuleAccessor,
+                        index: libc::c_uint,
                     ) -> i32;
                 }
                 extern "C" {
@@ -14942,15 +14971,43 @@ pub mod root {
                     ) -> u64;
                 }
                 extern "C" {
+                    /// Returns situation kind of the object
+                    ///
+                    /// # Arguments
+                    ///
+                    /// * `module_accessor` - Pointer to BattleObjectModuleAccessor
+                    ///
+                    /// # Example
+                    ///
+                    /// ```
+                    /// // is in air
+                    /// if StatusModule::situation_kind(module_accessor) == SITUATION_KIND_AIR {
+                    ///     // ...
+                    /// }
+                    /// ```
                     #[link_name = "\u{1}_ZN3app8lua_bind33StatusModule__situation_kind_implEPNS_26BattleObjectModuleAccessorE"]
                     pub fn situation_kind(
-                        arg1: *mut root::app::BattleObjectModuleAccessor,
+                        module_accessor: *mut root::app::BattleObjectModuleAccessor,
                     ) -> i32;
                 }
                 extern "C" {
+                    /// Returns previous situation kind of the object
+                    ///
+                    /// # Arguments
+                    ///
+                    /// * `module_accessor` - Pointer to BattleObjectModuleAccessor
+                    ///
+                    /// # Example
+                    ///
+                    /// ```
+                    /// // was in air
+                    /// if StatusModule::prev_situation_kind(module_accessor) == SITUATION_KIND_AIR {
+                    ///     // ...
+                    /// }
+                    /// ```
                     #[link_name = "\u{1}_ZN3app8lua_bind38StatusModule__prev_situation_kind_implEPNS_26BattleObjectModuleAccessorE"]
                     pub fn prev_situation_kind(
-                        arg1: *mut root::app::BattleObjectModuleAccessor,
+                        module_accessor: *mut root::app::BattleObjectModuleAccessor,
                     ) -> i32;
                 }
                 extern "C" {

--- a/src/cpp.rs
+++ b/src/cpp.rs
@@ -548,23 +548,23 @@ pub mod root {
             pub y2 : f32,
             pub z2 : f32,
             pub unk2: u32,
-            pub power_: f32, //damage
-            pub size_: f32, //size
-            pub vector_: i32, //angle
-            pub r_eff_: i32, //kbg
-            pub r_fix_: i32, //fkb
-            pub r_add_: i32, //bkb
-            pub slip_: f32, //trip chance
-            pub stop_frame_: f32, //hitlag multiplier
-            pub stop_delay_: f32, //sdi multiplier
-            pub node_: u64, //bone
-            pub check_type_: u16, //hitbits
-            pub target_situation_: u16, //ground/air
-            pub target_lr_: u16, //opponent's facing (for shulk back slash?)
-            pub target_part_: u16, //collision part
-            pub attr_: u64, //collision attribute
-            pub sound_level_: u16, //SFX level
-            pub sound_attr_: u16, //SFX type
+            pub power: f32, //damage
+            pub size: f32, //size
+            pub vector: i32, //angle
+            pub r_eff: i32, //kbg
+            pub r_fix: i32, //fkb
+            pub r_add: i32, //bkb
+            pub slip: f32, //trip chance
+            pub stop_frame: f32, //hitlag multiplier
+            pub stop_delay: f32, //sdi multiplier
+            pub node: u64, //bone
+            pub check_type: u16, //hitbits
+            pub target_situation: u16, //ground/air
+            pub target_lr: u16, //opponent's facing (for shulk back slash?)
+            pub target_part: u16, //collision part
+            pub attr: u64, //collision attribute
+            pub sound_level: u16, //SFX level
+            pub sound_attr: u16, //SFX type
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone)]

--- a/src/cpp.rs
+++ b/src/cpp.rs
@@ -164,6 +164,12 @@ pub mod root {
     }
     impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 
+    #[derive(Copy, Clone, Default, Debug)]
+    #[repr(C)]
+    pub struct lua_State {
+        pub _address: u64
+    }
+
     pub mod app {
         #[allow(unused_imports)]
         use self::super::super::root;
@@ -175,6 +181,11 @@ pub mod root {
             pub struct enSEType {
                 pub _address: u8,
             }
+        }
+        #[derive(Copy, Clone, Default, Debug)]
+        #[repr(C)]
+        pub struct BattleObject {
+            pub _address: u64
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone)]
@@ -529,21 +540,31 @@ pub mod root {
         // r_fix_damage_speed_up_: bool //whether or not to undergo balloon knockback during set knockback
         /// ```
         pub struct AttackData {
-            x: f32,
-            y: f32,
-            z: f32,
-            x2: i32,
-            y2: u64,
-            z3: u64,
-            power: f32,
-            size: f32,
-            angle: i32,
-            kbg: i32,
-            fkb: i32,
-            bkb: i32,
-            slip: i32,
-            hitlag: f32,
-            remainingUnks: [u64; 30]
+            pub x : f32,
+            pub y : f32,
+            pub z : f32,
+            pub unk1: u32,
+            pub x2 : f32,
+            pub y2 : f32,
+            pub z2 : f32,
+            pub unk2: u32,
+            pub power_: f32, //damage
+            pub size_: f32, //size
+            pub vector_: i32, //angle
+            pub r_eff_: i32, //kbg
+            pub r_fix_: i32, //fkb
+            pub r_add_: i32, //bkb
+            pub slip_: f32, //trip chance
+            pub stop_frame_: f32, //hitlag multiplier
+            pub stop_delay_: f32, //sdi multiplier
+            pub node_: u64, //bone
+            pub check_type_: u16, //hitbits
+            pub target_situation_: u16, //ground/air
+            pub target_lr_: u16, //opponent's facing (for shulk back slash?)
+            pub target_part_: u16, //collision part
+            pub attr_: u64, //collision attribute
+            pub sound_level_: u16, //SFX level
+            pub sound_attr_: u16, //SFX type
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone)]
@@ -638,7 +659,7 @@ pub mod root {
         #[repr(C)]
         #[derive(Debug, Copy, Clone)]
         pub struct SituationKind {
-            pub _address: u8,
+            pub situation_kind: i32,
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone)]
@@ -2168,7 +2189,7 @@ pub mod root {
                     pub fn damage(
                         arg1: *mut root::app::BattleObjectModuleAccessor,
                         arg2: libc::c_int,
-                    ) -> u64;
+                    ) -> f32;
                 }
                 extern "C" {
                     #[link_name = "\u{1}_ZN3app8lua_bind27DamageModule__reaction_implEPNS_26BattleObjectModuleAccessorEi"]
@@ -7349,15 +7370,15 @@ pub mod root {
                 }
                 extern "C" {
                     #[link_name = "\u{1}_ZN3app8lua_bind25PostureModule__pos_x_implEPNS_26BattleObjectModuleAccessorE"]
-                    pub fn pos_x(arg1: *mut root::app::BattleObjectModuleAccessor) -> u64;
+                    pub fn pos_x(arg1: *mut root::app::BattleObjectModuleAccessor) -> f32;
                 }
                 extern "C" {
                     #[link_name = "\u{1}_ZN3app8lua_bind25PostureModule__pos_y_implEPNS_26BattleObjectModuleAccessorE"]
-                    pub fn pos_y(arg1: *mut root::app::BattleObjectModuleAccessor) -> u64;
+                    pub fn pos_y(arg1: *mut root::app::BattleObjectModuleAccessor) -> f32;
                 }
                 extern "C" {
                     #[link_name = "\u{1}_ZN3app8lua_bind25PostureModule__pos_z_implEPNS_26BattleObjectModuleAccessorE"]
-                    pub fn pos_z(arg1: *mut root::app::BattleObjectModuleAccessor) -> u64;
+                    pub fn pos_z(arg1: *mut root::app::BattleObjectModuleAccessor) -> f32;
                 }
                 extern "C" {
                     #[link_name = "\u{1}_ZN3app8lua_bind27PostureModule__set_pos_implEPNS_26BattleObjectModuleAccessorERKN3phx8Vector3fE"]
@@ -14846,7 +14867,7 @@ pub mod root {
                     #[link_name = "\u{1}_ZN3app8lua_bind30StatusModule__status_kind_implEPNS_26BattleObjectModuleAccessorE"]
                     pub fn status_kind(
                         arg1: *mut root::app::BattleObjectModuleAccessor,
-                    ) -> u64;
+                    ) -> i32;
                 }
                 extern "C" {
                     #[link_name = "\u{1}_ZN3app8lua_bind35StatusModule__status_kind_next_implEPNS_26BattleObjectModuleAccessorE"]
@@ -14876,7 +14897,7 @@ pub mod root {
                     pub fn prev_status_kind(
                         arg1: *mut root::app::BattleObjectModuleAccessor,
                         arg2: libc::c_uint,
-                    ) -> u64;
+                    ) -> i32;
                 }
                 extern "C" {
                     #[link_name = "\u{1}_ZN3app8lua_bind38StatusModule__change_status_force_implEPNS_26BattleObjectModuleAccessorEib"]
@@ -14890,13 +14911,13 @@ pub mod root {
                     #[link_name = "\u{1}_ZN3app8lua_bind33StatusModule__situation_kind_implEPNS_26BattleObjectModuleAccessorE"]
                     pub fn situation_kind(
                         arg1: *mut root::app::BattleObjectModuleAccessor,
-                    ) -> u64;
+                    ) -> i32;
                 }
                 extern "C" {
                     #[link_name = "\u{1}_ZN3app8lua_bind38StatusModule__prev_situation_kind_implEPNS_26BattleObjectModuleAccessorE"]
                     pub fn prev_situation_kind(
                         arg1: *mut root::app::BattleObjectModuleAccessor,
-                    ) -> u64;
+                    ) -> i32;
                 }
                 extern "C" {
                     #[link_name = "\u{1}_ZN3app8lua_bind39StatusModule__is_situation_changed_implEPNS_26BattleObjectModuleAccessorE"]

--- a/src/cpp/l2c_value.rs
+++ b/src/cpp/l2c_value.rs
@@ -13,20 +13,6 @@ pub union L2CValueInner {
     pub raw_innerfunc: *mut L2CInnerFunctionBase,
 }
 
-impl fmt::Debug for L2CValueInner {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unsafe {
-            f.debug_tuple("")
-            .field(&self.raw)
-            .field(&self.raw_float)
-            .field(&self.raw_pointer)
-            .field(&self.raw_table)
-            .field(&self.raw_innerfunc)
-            .finish()
-        }
-    }
-}
-
 #[repr(u32)]
 #[derive(Copy, Clone, Debug)]
 pub enum L2CValueType {
@@ -41,13 +27,52 @@ pub enum L2CValueType {
     String = 8
 }
 
-#[derive(Copy, Clone, Default, Debug)]
+#[derive(Copy, Clone, Default)]
 #[repr(C)]
 pub struct L2CValue {
     pub val_type: L2CValueType,
     pub unk1: u32,
     pub inner: L2CValueInner,
     pub unk2: u8, // for enforcing X8 AArch64 struct behavior
+}
+
+impl fmt::Debug for L2CValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unsafe {
+            match self.val_type {
+                L2CValueType::Void => f.debug_tuple("")
+                                        .field(&self.val_type)
+                                        .field(&self.inner.raw)
+                                        .finish(),
+                L2CValueType::Bool => f.debug_tuple("")
+                                        .field(&self.val_type)
+                                        .field(&(self.inner.raw != 0))
+                                        .finish(),
+                L2CValueType::Int => f.debug_tuple("")
+                                        .field(&self.val_type)
+                                        .field(&self.inner.raw)
+                                        .finish(),
+                L2CValueType::Num => f.debug_tuple("")
+                                        .field(&self.val_type)
+                                        .field(&self.inner.raw_float)
+                                        .finish(),
+                L2CValueType::InnerFunc => f.debug_tuple("")
+                                        .field(&self.val_type)
+                                        .field(&self.inner.raw_innerfunc)
+                                        .finish(),
+                L2CValueType::Hash => f.debug_tuple("")
+                                        .field(&self.val_type)
+                                        .field(&self.inner.raw)
+                                        .finish(),
+                _ => f.debug_tuple("")
+                        .field(&self.val_type)
+                        .field(&self.unk1)
+                        .field(&self.inner.raw)
+                        .field(&self.unk2)
+                        .finish()
+            }
+        }
+    }
 }
 
 impl L2CValue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,12 @@ pub mod crc32;
 #[doc(hidden)]
 pub mod cpp;
 
+#[doc(hidden)]
+pub mod common;
+
+#[doc(inline)]
+pub use common::root::*;
+
 #[doc(inline)]
 pub use cpp::root::*;
 


### PR DESCRIPTION
- Add headers from lua2cpp_common.nro. Some functions are ignored (so far, GraphicsModule and the `bind_address` calls because they are not useful.
- Various useful changes to original `main` headers.

Example working hook:

```rs
#[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_sub_guard_cont)]
pub unsafe fn handle_sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue {
    let module_accessor = sv_system::battle_object_module_accessor(fighter.lua_state_agent);
    if true { // (*menu).MASH_STATE == MASH_ATTACK && (*menu).ATTACK_STATE == MASH_GRAB {
        if StatusModule::prev_status_kind(module_accessor, 0) == FIGHTER_STATUS_KIND_GUARD_DAMAGE {
            if WorkModule::get_int(module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_INVALID_CATCH_FRAME) == 0 {
                if WorkModule::is_enable_transition_term(module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH) {
                    fighter.fighter_base.change_status(L2CValue::new_int(*FIGHTER_STATUS_KIND_CATCH as u64), L2CValue::new_bool(true));
                }
            }
        }
    }
    original!()(fighter)
}

fn nro_main(nro: &NroInfo) {
    match nro.name {
        "common" => 
                {
                    println!("Loaded common NRO!");
                    skyline::install_hook!(handle_sub_guard_cont);
                },
        _ => ()
    }
}

#[skyline::main(name = "test")]
pub fn main() {
    nro::add_hook(nro_main).unwrap();
}
```