### PR TITLE
Fixed typo

### DIFF
--- a/src/cpp.rs
+++ b/src/cpp.rs
@@ -1243,7 +1243,7 @@ pub mod root {
             }
             extern "C" {
                 #[link_name = "\u{1}_ZN3app24FighterSpecializer_Brave23special_lw_select_indexERNS_7FighterEi"]
-                pub fn special_lw_command_index(
+                pub fn special_lw_select_index(
                     arg1: *mut root::app::Fighter,
                     arg2: i32,
                 ) -> u64;


### PR DESCRIPTION
In my original commit, I accidentally wrote a function as "special_lw_command_index" when it was actually "special_lw_select_index", my b