### PR TITLE
Implement From for u32 on LuaConst

### DIFF
--- a/src/cpp/l2c_value.rs
+++ b/src/cpp/l2c_value.rs
@@ -425,6 +425,12 @@ impl From<LuaConst> for i32 {
     }
 }
 
+impl From<LuaConst> for u32 {
+    fn from(lua_const: LuaConst) -> Self {
+        *lua_const as u32
+    }
+}
+
 impl Clone for LuaConst {
     fn clone(&self) -> Self {
         LuaConst::new(self.lua_bind_hash)


### PR DESCRIPTION
**Fully tested and working**

Some functions take a u32. From what I've seen, about 95% of the time that u32 is a lua const, so we've been just doing
```
func(blah, blah, LUA_CONST_HERE as u32);
```
To satisfy the compiler. It's just extra code at that point, so implementing this just makes things easier without any tradeoffs.