### PR TITLE
fix warning on compile

### DIFF
--- a/src/resource.rs
+++ b/src/resource.rs
@@ -115,11 +115,12 @@ impl Table1Entry {
 
 impl fmt::Display for Table1Entry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let table2_index = self.table2_index;
         unsafe {
             write!(
                 f,
                 "Table2 index: {} (In Table2: {})",
-                self.table2_index,
+                table2_index,
                 self.in_table_2 != 0
             )
         }


### PR DESCRIPTION
when using this crate in other projects, the compiler would spit out an unaligned references warning, this pull request should fix that