### PR TITLE
Incorporate upstream changes from nnSdk

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(const_if_match, const_loop, track_caller, proc_macro_hygiene)]
-#![feature(asm)]
+#![feature(proc_macro_hygiene)]
 #![feature(associated_type_bounds)]
 #![feature(simd_ffi)] // lol sorry jam
 

--- a/src/lua_const.rs
+++ b/src/lua_const.rs
@@ -1,7 +1,5 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
-#![allow(non_snake_case)]
-use crate::cpp::l2c_value::L2CValue;
 
 macro_rules! lua_consts {
     ($($ident:ident),* $(,)?) => {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -116,14 +116,12 @@ impl Table1Entry {
 impl fmt::Display for Table1Entry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let table2_index = self.table2_index;
-        unsafe {
-            write!(
-                f,
-                "Table2 index: {} (In Table2: {})",
-                table2_index,
-                self.in_table_2 != 0
-            )
-        }
+        write!(
+            f,
+            "Table2 index: {} (In Table2: {})",
+            table2_index,
+            self.in_table_2 != 0
+        )
     }
 }
 

--- a/src/ui2d.rs
+++ b/src/ui2d.rs
@@ -1,5 +1,5 @@
 use skyline::libc::c_char;
-use skyline::nn::ui2d::{Pane, TextBox};
+use nnsdk::ui2d::{Pane, TextBox};
 
 // TODO: Offset search
 #[skyline::from_offset(0x59970)]


### PR DESCRIPTION
After recent updates to the `uid2` module in `nnsdk-rs`, the build fails. The changes in this PR adapt the code to import from the `nnsdk` library properly.